### PR TITLE
Fix menu app build error - NoAdapterInstalled

### DIFF
--- a/menuapp/astro.config.mjs
+++ b/menuapp/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
-  output: 'server',
+  output: 'static',
   build: {
     format: 'directory'
   },


### PR DESCRIPTION
## Summary
- Fixed NoAdapterInstalled error in menu app build by changing Astro config from `server` to `static` output
- Menu app is designed for static deployment on CloudFlare Pages and doesn't need server-side rendering

## Changes
- Updated `menuapp/astro.config.mjs` to use `output: 'static'` instead of `output: 'server'`

## Test plan
- [x] Verified `npm run build` in menuapp now succeeds without errors
- [x] Build generates static files correctly in dist/ directory

Fixes #104

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build output to generate a fully static site instead of a server-rendered deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->