### PR TITLE
feat: redesign website with grayscale theme and Crimson Pro font

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -16,6 +16,9 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet">
     <title>{title}</title>
     <meta name="description" content={description} />
   </head>
@@ -25,22 +28,22 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
           <div class="flex items-center">
-            <a href="/" class="text-2xl font-bold text-gray-900 hover:text-primary-600 transition-colors">letsorder</a>
+            <a href="/" class="text-2xl font-bold font-heading text-gray-900 hover:text-gray-700 transition-colors">Lets Order!</a>
           </div>
           
           <!-- Desktop Navigation -->
           <div class="hidden md:block">
             <div class="ml-10 flex items-baseline space-x-4">
-              <a href="/features" class="text-gray-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium">Features</a>
-              <a href="/pricing" class="text-gray-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium">Pricing</a>
-              <a href="/faq" class="text-gray-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium">FAQ</a>
-              <a href="/live-demo" class="text-gray-600 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium">Live Demo</a>
+              <a href="/features" class="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium">Features</a>
+              <a href="/pricing" class="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium">Pricing</a>
+              <a href="/faq" class="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium">FAQ</a>
+              <a href="/live-demo" class="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium">Live Demo</a>
             </div>
           </div>
           
           <!-- Mobile Menu Button -->
           <div class="md:hidden">
-            <button id="mobile-menu-toggle" class="text-gray-600 hover:text-primary-600 p-2">
+            <button id="mobile-menu-toggle" class="text-gray-600 hover:text-gray-800 p-2">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
               </svg>
@@ -51,10 +54,10 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         <!-- Mobile Navigation Menu -->
         <div id="mobile-menu" class="hidden md:hidden bg-white border-t border-gray-200">
           <div class="px-2 pt-2 pb-3 space-y-1">
-            <a href="/features" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-primary-600 hover:bg-gray-50">Features</a>
-            <a href="/pricing" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-primary-600 hover:bg-gray-50">Pricing</a>
-            <a href="/faq" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-primary-600 hover:bg-gray-50">FAQ</a>
-            <a href="/live-demo" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-primary-600 hover:bg-gray-50">Live Demo</a>
+            <a href="/features" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">Features</a>
+            <a href="/pricing" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">Pricing</a>
+            <a href="/faq" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">FAQ</a>
+            <a href="/live-demo" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">Live Demo</a>
           </div>
         </div>
       </div>
@@ -68,26 +71,18 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         <div class="grid lg:grid-cols-3 gap-12">
           <!-- CTA Section -->
           <div class="lg:col-span-1">
-            <h3 class="text-2xl font-bold mb-4">
+            <h3 class="text-2xl font-bold font-heading mb-4">
               Ready to streamline your restaurant?
             </h3>
             <p class="text-gray-400 mb-6">
               See how letsorder can help you improve efficiency and enhance customer experience.
             </p>
-            <div class="flex flex-col sm:flex-row lg:flex-col gap-4">
-              <a href="/live-demo" class="border-2 border-white text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-white hover:text-primary-600 transition-colors">
-                Live Demo
-              </a>
-              <a href={adminRegisterUrl} class="bg-primary-400 text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-primary-500 transition-colors">
-                Get Started for Free
-              </a>
-            </div>
           </div>
 
           <!-- Links Section -->
           <div class="lg:col-span-2 grid sm:grid-cols-3 gap-8">
             <div>
-              <h4 class="font-semibold mb-4">Product</h4>
+              <h4 class="font-semibold font-heading mb-4">Product</h4>
               <ul class="space-y-2 text-gray-400">
                 <li><a href="/features" class="hover:text-white">Features</a></li>
                 <li><a href="/pricing" class="hover:text-white">Pricing</a></li>
@@ -96,7 +91,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             </div>
 
             <div>
-              <h4 class="font-semibold mb-4">Support</h4>
+              <h4 class="font-semibold font-heading mb-4">Support</h4>
               <ul class="space-y-2 text-gray-400">
                 <li><a href="/contact" class="hover:text-white">Contact Us</a></li>
                 <li><a href="#" class="hover:text-white">Documentation</a></li>
@@ -104,7 +99,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             </div>
 
             <div>
-              <h4 class="font-semibold mb-4">Company</h4>
+              <h4 class="font-semibold font-heading mb-4">Company</h4>
               <ul class="space-y-2 text-gray-400">
                 <li><a href="/about-us" class="hover:text-white">About</a></li>
                 <li><a href="/privacy-policy" class="hover:text-white">Privacy Policy</a></li>

--- a/website/src/pages/faq.astro
+++ b/website/src/pages/faq.astro
@@ -12,7 +12,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   <!-- Hero Section -->
   <section class="bg-gray-50 py-16">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+      <h1 class="text-4xl md:text-5xl font-bold font-heading text-gray-900 mb-6">
         Frequently Asked Questions
       </h1>
       <p class="text-xl text-gray-600">
@@ -27,11 +27,11 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- Getting Started -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">Getting Started</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">Getting Started</h2>
         
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How do I get started?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How do I get started?</h3>
             <p class="text-gray-600 mb-4">Getting started with letsorder is simple:</p>
             <ol class="list-decimal list-inside text-gray-600 space-y-2">
               <li>Sign up for a free account with your email and password</li>
@@ -45,12 +45,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Why do I need 2 managers to register?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Why do I need 2 managers to register?</h3>
             <p class="text-gray-600">This is a security measure to ensure legitimate restaurant registrations. The first manager becomes the super admin with full control, and they can invite additional managers with customizable permissions.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How long does setup take?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How long does setup take?</h3>
             <p class="text-gray-600">Most restaurants complete their setup in under 30 minutes. This includes creating menu sections, adding items, and generating QR codes for tables.</p>
           </div>
         </div>
@@ -58,26 +58,26 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- Free Trial & Pricing -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">Free Trial & Pricing</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">Free Trial & Pricing</h2>
 
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Is there a free trial?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Is there a free trial?</h3>
             <p class="text-gray-600">Yes! We offer a 30-day free trial with full access to all features. No credit card required to start. You can set up your entire restaurant, create menus, and test the system completely free for 30 days.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">What happens after the free trial ends?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What happens after the free trial ends?</h3>
             <p class="text-gray-600">After 30 days, you can subscribe to our Standard plan for $60/year. If you choose not to subscribe, your account will be paused but your data will be preserved for 90 days in case you change your mind.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">What payment methods are accepted?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What payment methods are accepted?</h3>
             <p class="text-gray-600">We accept all major credit cards (Visa, MasterCard, American Express) and bank transfers for annual payments. All payments are processed securely through our trusted payment partners.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Are there any hidden fees?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Are there any hidden fees?</h3>
             <p class="text-gray-600">No hidden fees whatsoever. No setup fees, no transaction fees, no per-order charges. The $60/year is all you pay for the Standard plan.</p>
           </div>
         </div>
@@ -85,26 +85,26 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- Menu Management -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">Menu Management</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">Menu Management</h2>
 
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I customize the menu?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I customize the menu?</h3>
             <p class="text-gray-600">Absolutely! You have full control over your menu. Create custom sections (appetizers, mains, desserts, etc.), add items with descriptions and prices, and organize everything exactly how you want it. You can update your menu anytime.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How many menu items can I add?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How many menu items can I add?</h3>
             <p class="text-gray-600">There's no limit on menu items with the Standard plan. Add as many sections and items as you need for your restaurant.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I add images to menu items?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I add images to menu items?</h3>
             <p class="text-gray-600">Currently, letsorder focuses on text-based menus for simplicity and fast loading. Image support may be added in future updates based on user feedback.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I have different menus for different times?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I have different menus for different times?</h3>
             <p class="text-gray-600">The current version supports one menu per restaurant to keep things simple. Multiple menus (breakfast, lunch, dinner) may be added in future updates.</p>
           </div>
         </div>
@@ -112,26 +112,26 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- QR Codes & Tables -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">QR Codes & Tables</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">QR Codes & Tables</h2>
 
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How do QR codes work?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How do QR codes work?</h3>
             <p class="text-gray-600">Each table or room gets a unique QR code that links to your menu. When customers scan it with their phone camera, they're taken directly to your menu where they can browse items and place orders. No app download required!</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How many tables can I have?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How many tables can I have?</h3>
             <p class="text-gray-600">The Standard plan supports up to 100 tables or rooms. For larger venues, contact us about our Enterprise plan with custom limits.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I regenerate QR codes?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I regenerate QR codes?</h3>
             <p class="text-gray-600">Yes! Managers can refresh QR codes anytime for security or if codes get damaged. You can also generate printable pages with multiple QR codes at once.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">What format are the QR codes?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What format are the QR codes?</h3>
             <p class="text-gray-600">QR codes are provided in formats that are easy to print and display. Each code includes the table/room name below it for easy identification by both staff and customers.</p>
           </div>
         </div>
@@ -139,26 +139,26 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- Orders & Operations -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">Orders & Operations</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">Orders & Operations</h2>
 
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How do customers place orders?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How do customers place orders?</h3>
             <p class="text-gray-600">Customers scan the QR code, browse your menu, add items to their order, review the summary, and place the order. It's all done through their web browser - no app needed!</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Do customers need to create accounts?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Do customers need to create accounts?</h3>
             <p class="text-gray-600">No! Customers can browse menus and place orders without any registration or login. This keeps the experience fast and friction-free.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">How do I see new orders?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">How do I see new orders?</h3>
             <p class="text-gray-600">Orders appear instantly in your management dashboard. You can see which table placed each order, what items were ordered, and manage your kitchen workflow efficiently.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can customers modify orders after placing them?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can customers modify orders after placing them?</h3>
             <p class="text-gray-600">Currently, orders cannot be modified after placement to keep operations simple. Customers can place additional orders if needed.</p>
           </div>
         </div>
@@ -166,31 +166,31 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <!-- Technical & Support -->
       <div class="mb-12">
-        <h2 class="text-2xl font-bold text-gray-900 mb-8">Technical & Support</h2>
+        <h2 class="text-2xl font-bold font-heading text-gray-900 mb-8">Technical & Support</h2>
 
         <div class="space-y-6">
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">What devices does letsorder work on?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What devices does letsorder work on?</h3>
             <p class="text-gray-600">letsorder works on any device with a web browser - smartphones, tablets, laptops, and desktops. The customer menu is optimized for mobile devices, while the management interface works great on all screen sizes.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Do I need internet connection?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Do I need internet connection?</h3>
             <p class="text-gray-600">Yes, letsorder requires internet connection for both customers placing orders and managers viewing orders. This ensures real-time synchronization and the best experience.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Is my data secure?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Is my data secure?</h3>
             <p class="text-gray-600">Yes! We use industry-standard security measures including encrypted data transmission, secure authentication, and continuous database backups. Your restaurant data is safe and always available.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">What kind of support do you provide?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What kind of support do you provide?</h3>
             <p class="text-gray-600">We provide email support for all users, with priority support for Enterprise customers. We also maintain comprehensive documentation and help resources.</p>
           </div>
 
           <div class="bg-white border rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I export my data?</h3>
+            <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I export my data?</h3>
             <p class="text-gray-600">Yes, you can export your menu data and order history at any time. We believe your data belongs to you and should always be accessible.</p>
           </div>
         </div>
@@ -199,17 +199,17 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
     </section>
 
     <!-- CTA Section -->
-    <section class="py-16 bg-blue-600 text-white">
+    <section class="py-16 bg-gray-700 text-white">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-        <h2 class="text-3xl font-bold mb-6">Still Have Questions?</h2>
-        <p class="text-xl text-blue-100 mb-8">
+        <h2 class="text-3xl font-bold font-heading mb-6">Still Have Questions?</h2>
+        <p class="text-xl text-gray-200 mb-8">
           We're here to help! Contact us or start your free trial to see letsorder in action.
         </p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
-          <a href={adminRegisterUrl} class="bg-white text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
+          <a href={adminRegisterUrl} class="bg-white text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
             Start Free Trial
           </a>
-          <a href="#" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-blue-600 transition-colors">
+          <a href="#" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-gray-800 transition-colors">
             Contact Support
           </a>
         </div>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -10,19 +10,19 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   description="Explore the powerful features of letsorder, designed to streamline your restaurant management and enhance the customer experience."
 >
   <!-- Features Overview Hero -->
-  <section class="bg-gradient-to-r from-primary-400 to-secondary-400 text-white py-20">
+  <section class="bg-gradient-to-r from-gray-600 to-gray-700 text-white py-20">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-6xl font-bold mb-6">
+      <h1 class="text-4xl md:text-6xl font-bold font-heading mb-6">
         Powerful Features for Modern Restaurants
       </h1>
-      <p class="text-xl text-pink-100 max-w-3xl mx-auto mb-8">
+      <p class="text-xl text-gray-200 max-w-3xl mx-auto mb-8">
         Discover how letsorder streamlines restaurant management and enhances the customer experience with our comprehensive feature set.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="/features/admin" class="bg-white text-primary-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
+        <a href="/features/admin" class="bg-white text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
           Admin Features
         </a>
-        <a href="/features/menu" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-primary-600 transition-colors">
+        <a href="/features/menu" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-gray-800 transition-colors">
           Menu Features
         </a>
       </div>
@@ -35,43 +35,43 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
       <div class="grid lg:grid-cols-2 gap-16">
         <!-- Admin Features Card -->
         <div class="text-center">
-          <div class="bg-primary-50 rounded-2xl p-8">
-            <div class="w-20 h-20 bg-primary-400 rounded-xl mx-auto mb-6 flex items-center justify-center">
+          <div class="bg-gray-50 rounded-2xl p-8">
+            <div class="w-20 h-20 bg-gray-600 rounded-xl mx-auto mb-6 flex items-center justify-center">
               <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
               </svg>
             </div>
-            <h3 class="text-2xl font-bold text-gray-900 mb-4">For Restaurant Managers</h3>
+            <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">For Restaurant Managers</h3>
             <p class="text-gray-600 mb-6">
               Complete restaurant management tools including menu editing, QR code generation, order tracking, and team collaboration.
             </p>
             <ul class="text-left text-gray-600 space-y-2 mb-8">
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-primary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Dynamic menu management
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-primary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 QR code generation & management
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-primary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Real-time order tracking
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-primary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Team collaboration tools
               </li>
             </ul>
-            <a href="/features/admin" class="bg-primary-400 text-white px-6 py-3 rounded-lg font-semibold hover:bg-primary-500 transition-colors inline-block">
+            <a href="/features/admin" class="bg-gray-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-gray-700 transition-colors inline-block">
               Explore Admin Features
             </a>
           </div>
@@ -79,43 +79,43 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
         <!-- Menu Features Card -->
         <div class="text-center">
-          <div class="bg-secondary-50 rounded-2xl p-8">
-            <div class="w-20 h-20 bg-secondary-400 rounded-xl mx-auto mb-6 flex items-center justify-center">
+          <div class="bg-gray-50 rounded-2xl p-8">
+            <div class="w-20 h-20 bg-gray-500 rounded-xl mx-auto mb-6 flex items-center justify-center">
               <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
               </svg>
             </div>
-            <h3 class="text-2xl font-bold text-gray-900 mb-4">For Your Customers</h3>
+            <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">For Your Customers</h3>
             <p class="text-gray-600 mb-6">
               Seamless mobile ordering experience with instant menu access, intuitive navigation, and real-time order tracking.
             </p>
             <ul class="text-left text-gray-600 space-y-2 mb-8">
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-secondary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Instant QR code menu access
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-secondary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Mobile-first design
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-secondary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Simple ordering process
               </li>
               <li class="flex items-center">
-                <svg class="w-4 h-4 text-secondary-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Real-time order updates
               </li>
             </ul>
-            <a href="/features/menu" class="bg-secondary-400 text-white px-6 py-3 rounded-lg font-semibold hover:bg-secondary-500 transition-colors inline-block">
+            <a href="/features/menu" class="bg-gray-500 text-white px-6 py-3 rounded-lg font-semibold hover:bg-gray-600 transition-colors inline-block">
               Explore Menu Features
             </a>
           </div>
@@ -128,7 +128,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   <section class="py-20 bg-gray-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16">
-        <h2 class="text-4xl font-bold text-gray-900 mb-4">Security & Reliability</h2>
+        <h2 class="text-4xl font-bold font-heading text-gray-900 mb-4">Security & Reliability</h2>
         <p class="text-xl text-gray-600 max-w-3xl mx-auto">
           Built on a robust and secure foundation to ensure your data is safe and your service is always available.
         </p>
@@ -136,58 +136,58 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-accent-400 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-600 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Secure Authentication</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Secure Authentication</h3>
           <p class="text-gray-600">JWT-based authentication ensures that only authorized managers can access the admin dashboard.</p>
         </div>
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-primary-400 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-500 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Role-Based Access Control</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Role-Based Access Control</h3>
           <p class="text-gray-600">Fine-grained permissions control what each manager can see and do.</p>
         </div>
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-secondary-400 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-700 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Database Backups</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Database Backups</h3>
           <p class="text-gray-600">Litestream provides continuous, real-time backups of your database to a secure, off-site location.</p>
         </div>
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-accent-500 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-600 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Error Monitoring</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Error Monitoring</h3>
           <p class="text-gray-600">Integrated with Sentry for real-time error tracking and performance monitoring.</p>
         </div>
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-primary-500 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-500 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Modern Tech Stack</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Modern Tech Stack</h3>
           <p class="text-gray-600">Backend built with Rust (Actix Web) for performance and reliability. Admin app built with SolidJS for a fast user experience.</p>
         </div>
         <div class="bg-white p-8 rounded-lg shadow-sm border">
-          <div class="w-12 h-12 bg-secondary-500 rounded-lg mb-4 flex items-center justify-center">
+          <div class="w-12 h-12 bg-gray-700 rounded-lg mb-4 flex items-center justify-center">
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
             </svg>
           </div>
-          <h3 class="text-2xl font-semibold text-gray-900 mb-4">Guest-Friendly</h3>
+          <h3 class="text-2xl font-semibold font-heading text-gray-900 mb-4">Guest-Friendly</h3>
           <p class="text-gray-600">The customer-facing menu is a lightweight Astro application, ensuring fast load times on any device.</p>
         </div>
       </div>
@@ -195,19 +195,19 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   </section>
 
   <!-- Try Demo CTA -->
-  <section class="py-16 bg-gradient-to-r from-primary-400 to-secondary-400">
+  <section class="py-16 bg-gradient-to-r from-gray-600 to-gray-700">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl font-bold text-white mb-6">
+      <h2 class="text-3xl font-bold font-heading text-white mb-6">
         Ready to Experience letsorder?
       </h2>
-      <p class="text-xl text-pink-100 mb-8">
+      <p class="text-xl text-gray-200 mb-8">
         Try our live demos to see how both admin and menu features work together.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="/live-demo" class="bg-white text-primary-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
+        <a href="/live-demo" class="bg-white text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
           Try Live Demo
         </a>
-        <a href={adminRegisterUrl} class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-primary-600 transition-colors">
+        <a href={adminRegisterUrl} class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-gray-800 transition-colors">
           Get Started
         </a>
       </div>

--- a/website/src/pages/features/admin.astro
+++ b/website/src/pages/features/admin.astro
@@ -7,12 +7,12 @@ import Layout from '../../layouts/Layout.astro';
   description="Explore the powerful admin features of letsorder, designed to streamline your restaurant management operations."
 >
   <!-- Admin Features Hero -->
-  <section class="bg-gradient-to-r from-primary-400 to-primary-600 text-white py-16">
+  <section class="bg-gradient-to-r from-gray-600 to-gray-800 text-white py-16">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold mb-6">
+      <h1 class="text-4xl md:text-5xl font-bold font-heading mb-6">
         Admin Dashboard Features
       </h1>
-      <p class="text-xl text-pink-100 max-w-3xl mx-auto">
+      <p class="text-xl text-gray-200 max-w-3xl mx-auto">
         A comprehensive suite of tools to manage your restaurant efficiently, from menu updates to order tracking.
       </p>
     </div>
@@ -30,12 +30,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Dashboard Overview</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Dashboard Overview</h3>
                   <p class="text-sm text-gray-600">Complete restaurant management at your fingertips</p>
                 </div>
               </div>
@@ -45,12 +45,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Menu Management</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Menu Management</h3>
                   <p class="text-sm text-gray-600">Create and organize menus with drag-and-drop</p>
                 </div>
               </div>
@@ -60,12 +60,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">QR Code Generation</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">QR Code Generation</h3>
                   <p class="text-sm text-gray-600">Generate and manage table QR codes</p>
                 </div>
               </div>
@@ -75,12 +75,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-800 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Order Management</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Order Management</h3>
                   <p class="text-sm text-gray-600">Track and manage orders in real-time</p>
                 </div>
               </div>
@@ -89,12 +89,12 @@ import Layout from '../../layouts/Layout.astro';
         </div>
         
         <!-- Desktop Navigation Buttons -->
-        <button id="admin-prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-primary-600">
+        <button id="admin-prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="admin-next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-primary-600">
+        <button id="admin-next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -109,12 +109,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Dashboard Overview</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Dashboard Overview</h3>
                   <p class="text-sm text-gray-600">Complete restaurant management at your fingertips</p>
                 </div>
               </div>
@@ -124,12 +124,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Menu Management</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Menu Management</h3>
                   <p class="text-sm text-gray-600">Create and organize menus with drag-and-drop</p>
                 </div>
               </div>
@@ -139,12 +139,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">QR Code Generation</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">QR Code Generation</h3>
                   <p class="text-sm text-gray-600">Generate and manage table QR codes</p>
                 </div>
               </div>
@@ -154,12 +154,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-800 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Order Management</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Order Management</h3>
                   <p class="text-sm text-gray-600">Track and manage orders in real-time</p>
                 </div>
               </div>
@@ -168,12 +168,12 @@ import Layout from '../../layouts/Layout.astro';
         </div>
         
         <!-- Mobile Navigation Buttons - Overlaid -->
-        <button id="admin-prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-primary-600 hover:bg-white z-10">
+        <button id="admin-prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="admin-next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-primary-600 hover:bg-white z-10">
+        <button id="admin-next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -182,10 +182,10 @@ import Layout from '../../layouts/Layout.astro';
       
       <!-- Dots Indicator -->
       <div class="flex justify-center mt-6 space-x-2">
-        <button class="admin-carousel-dot w-3 h-3 bg-primary-400 rounded-full" data-slide="0"></button>
-        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-primary-300" data-slide="1"></button>
-        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-primary-300" data-slide="2"></button>
-        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-primary-300" data-slide="3"></button>
+        <button class="admin-carousel-dot w-3 h-3 bg-gray-600 rounded-full" data-slide="0"></button>
+        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="1"></button>
+        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="2"></button>
+        <button class="admin-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="3"></button>
       </div>
     </div>
   </section>

--- a/website/src/pages/features/menu.astro
+++ b/website/src/pages/features/menu.astro
@@ -7,12 +7,12 @@ import Layout from '../../layouts/Layout.astro';
   description="Explore the customer-facing menu features of letsorder, designed for seamless mobile ordering experience."
 >
   <!-- Menu Features Hero -->
-  <section class="bg-gradient-to-r from-secondary-400 to-secondary-600 text-white py-16">
+  <section class="bg-gradient-to-r from-gray-600 to-gray-800 text-white py-16">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold mb-6">
+      <h1 class="text-4xl md:text-5xl font-bold font-heading mb-6">
         Guest Menu Experience
       </h1>
-      <p class="text-xl text-emerald-100 max-w-3xl mx-auto">
+      <p class="text-xl text-gray-200 max-w-3xl mx-auto">
         A seamless and modern dining experience for your guests, accessible from any smartphone.
       </p>
     </div>
@@ -30,12 +30,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Browse Menu</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Browse Menu</h3>
                   <p class="text-sm text-gray-600">Intuitive menu browsing with clear sections</p>
                 </div>
               </div>
@@ -45,12 +45,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4m0 0L7 13m0 0l-2.5 5H21M7 13v6a2 2 0 002 2h6a2 2 0 002-2v-6"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Shopping Cart</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Shopping Cart</h3>
                   <p class="text-sm text-gray-600">Easy cart management with floating indicator</p>
                 </div>
               </div>
@@ -60,12 +60,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Quick Checkout</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Quick Checkout</h3>
                   <p class="text-sm text-gray-600">Streamlined checkout with customer details</p>
                 </div>
               </div>
@@ -75,12 +75,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-sm mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-800 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Order Tracking</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Order Tracking</h3>
                   <p class="text-sm text-gray-600">Real-time order status updates</p>
                 </div>
               </div>
@@ -89,12 +89,12 @@ import Layout from '../../layouts/Layout.astro';
         </div>
         
         <!-- Desktop Navigation Buttons -->
-        <button id="menu-prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-secondary-600">
+        <button id="menu-prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="menu-next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-secondary-600">
+        <button id="menu-next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -109,12 +109,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Browse Menu</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Browse Menu</h3>
                   <p class="text-sm text-gray-600">Intuitive menu browsing with clear sections</p>
                 </div>
               </div>
@@ -124,12 +124,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4m0 0L7 13m0 0l-2.5 5H21M7 13v6a2 2 0 002 2h6a2 2 0 002-2v-6"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Shopping Cart</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Shopping Cart</h3>
                   <p class="text-sm text-gray-600">Easy cart management with floating indicator</p>
                 </div>
               </div>
@@ -139,12 +139,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Quick Checkout</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Quick Checkout</h3>
                   <p class="text-sm text-gray-600">Streamlined checkout with customer details</p>
                 </div>
               </div>
@@ -154,12 +154,12 @@ import Layout from '../../layouts/Layout.astro';
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-20 h-20 bg-secondary-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-20 h-20 bg-gray-800 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Order Tracking</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Order Tracking</h3>
                   <p class="text-sm text-gray-600">Real-time order status updates</p>
                 </div>
               </div>
@@ -168,12 +168,12 @@ import Layout from '../../layouts/Layout.astro';
         </div>
         
         <!-- Mobile Navigation Buttons - Overlaid -->
-        <button id="menu-prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-secondary-600 hover:bg-white z-10">
+        <button id="menu-prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="menu-next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-secondary-600 hover:bg-white z-10">
+        <button id="menu-next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -182,10 +182,10 @@ import Layout from '../../layouts/Layout.astro';
       
       <!-- Dots Indicator -->
       <div class="flex justify-center mt-6 space-x-2">
-        <button class="menu-carousel-dot w-3 h-3 bg-secondary-400 rounded-full" data-slide="0"></button>
-        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-secondary-300" data-slide="1"></button>
-        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-secondary-300" data-slide="2"></button>
-        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-secondary-300" data-slide="3"></button>
+        <button class="menu-carousel-dot w-3 h-3 bg-gray-600 rounded-full" data-slide="0"></button>
+        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="1"></button>
+        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="2"></button>
+        <button class="menu-carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="3"></button>
       </div>
     </div>
   </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,24 +10,24 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   description="Streamline your restaurant operations with QR code menus, instant ordering, and powerful management tools. Start your 30-day free trial today."
 >
   <!-- Hero Section -->
-  <section class="bg-gradient-to-r from-primary-400 to-primary-600 text-white">
+  <section class="bg-gradient-to-r from-gray-800 to-gray-900 text-white">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
       <div class="text-center">
-        <h1 class="text-4xl md:text-6xl font-bold mb-6">
+        <h1 class="text-5xl md:text-7xl font-light font-heading mb-6">
           Complete Menu Management & Ordering for Restaurants
         </h1>
-        <p class="text-xl md:text-2xl mb-8 text-pink-100 max-w-3xl mx-auto">
+        <p class="text-xl md:text-2xl mb-8 text-gray-200 max-w-3xl mx-auto">
           Streamline your restaurant operations with QR code menus, instant ordering, and powerful management tools. No payment integration needed.
         </p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
-          <a href={adminRegisterUrl} class="bg-white text-primary-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
+          <a href={adminRegisterUrl} class="bg-white text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors">
             Get Started for Free
           </a>
-          <a href="/live-demo" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-primary-600 transition-colors">
+          <a href="/live-demo" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-gray-800 transition-colors">
             Live Demo
           </a>
         </div>
-        <p class="mt-4 text-pink-200">30-day free trial • No credit card required</p>
+        <p class="mt-4 text-gray-300">30-day free trial • No credit card required</p>
       </div>
     </div>
   </section>
@@ -37,7 +37,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
     <!-- Header with container for desktop -->
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-12">
       <div class="text-center">
-        <h2 class="text-3xl font-bold text-gray-900 mb-4">
+        <h2 class="text-3xl font-bold font-heading text-gray-900 mb-4">
           See letsorder in Action
         </h2>
         <p class="text-lg text-gray-600">
@@ -56,12 +56,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-xs mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Admin Dashboard</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Admin Dashboard</h3>
                   <p class="text-sm text-gray-600">Manage menus, tables, and orders with ease</p>
                 </div>
               </div>
@@ -71,12 +71,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-xs mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Guest Menu</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Guest Menu</h3>
                   <p class="text-sm text-gray-600">Mobile-friendly ordering experience</p>
                 </div>
               </div>
@@ -86,12 +86,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0 px-4">
               <div class="bg-gray-100 rounded-lg aspect-[9/16] max-w-xs mx-auto flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">QR Codes</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">QR Codes</h3>
                   <p class="text-sm text-gray-600">Generate and manage table QR codes</p>
                 </div>
               </div>
@@ -100,12 +100,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         </div>
         
         <!-- Desktop Navigation Buttons -->
-        <button id="prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-primary-600">
+        <button id="prev-btn" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-primary-600">
+        <button id="next-btn" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white shadow-lg rounded-full p-2 text-gray-600 hover:text-gray-800">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -120,12 +120,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-primary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-600 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Admin Dashboard</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Admin Dashboard</h3>
                   <p class="text-sm text-gray-600">Manage menus, tables, and orders with ease</p>
                 </div>
               </div>
@@ -135,12 +135,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-secondary-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">Guest Menu</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Guest Menu</h3>
                   <p class="text-sm text-gray-600">Mobile-friendly ordering experience</p>
                 </div>
               </div>
@@ -150,12 +150,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
             <div class="w-full flex-shrink-0">
               <div class="bg-gray-100 aspect-[9/16] flex items-center justify-center">
                 <div class="text-center p-8">
-                  <div class="w-16 h-16 bg-accent-400 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                  <div class="w-16 h-16 bg-gray-700 rounded-lg mx-auto mb-4 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"></path>
                     </svg>
                   </div>
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2">QR Codes</h3>
+                  <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">QR Codes</h3>
                   <p class="text-sm text-gray-600">Generate and manage table QR codes</p>
                 </div>
               </div>
@@ -164,12 +164,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         </div>
         
         <!-- Mobile Navigation Buttons - Overlaid -->
-        <button id="prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-primary-600 hover:bg-white z-10">
+        <button id="prev-btn-mobile" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button id="next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-primary-600 hover:bg-white z-10">
+        <button id="next-btn-mobile" class="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 backdrop-blur-sm shadow-lg rounded-full p-3 text-gray-600 hover:text-gray-800 hover:bg-white z-10">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -178,9 +178,9 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
       
       <!-- Dots Indicator -->
       <div class="flex justify-center mt-6 space-x-2">
-        <button class="carousel-dot w-3 h-3 bg-primary-400 rounded-full" data-slide="0"></button>
-        <button class="carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-primary-300" data-slide="1"></button>
-        <button class="carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-primary-300" data-slide="2"></button>
+        <button class="carousel-dot w-3 h-3 bg-gray-600 rounded-full" data-slide="0"></button>
+        <button class="carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="1"></button>
+        <button class="carousel-dot w-3 h-3 bg-gray-300 rounded-full hover:bg-gray-500" data-slide="2"></button>
       </div>
     </div>
   </section>
@@ -189,7 +189,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   <section id="features" class="py-20 bg-gray-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16">
-        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+        <h2 class="text-3xl md:text-4xl font-bold font-heading text-gray-900 mb-4">
           Powerful Features to Grow Your Business
         </h2>
         <p class="text-xl text-gray-600 max-w-2xl mx-auto">
@@ -198,20 +198,20 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
       </div>
       <div class="grid md:grid-cols-3 gap-8 text-center">
         <div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-2">Menu Management</h3>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mb-2">Menu Management</h3>
           <p class="text-gray-600">Easily create, update, and organize your menus.</p>
         </div>
         <div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-2">QR Code Ordering</h3>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mb-2">QR Code Ordering</h3>
           <p class="text-gray-600">Contactless ordering for a safe and modern dining experience.</p>
         </div>
         <div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-2">Real-time Analytics</h3>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mb-2">Real-time Analytics</h3>
           <p class="text-gray-600">Gain insights into your sales and customer preferences.</p>
         </div>
       </div>
       <div class="text-center mt-12">
-        <a href="/features" class="text-primary-500 font-semibold hover:underline">
+        <a href="/features" class="text-gray-700 font-semibold hover:underline">
           See All Features &rarr;
         </a>
       </div>
@@ -223,7 +223,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid lg:grid-cols-2 gap-12 items-center">
         <div>
-          <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+          <h2 class="text-3xl md:text-4xl font-bold font-heading text-gray-900 mb-6">
             Seamless Experience for Your Guests
           </h2>
           <p class="text-xl text-gray-600 mb-8">
@@ -232,37 +232,37 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
           <div class="space-y-6">
             <div class="flex items-start">
-              <div class="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center mr-4 mt-1">
-                <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center mr-4 mt-1">
+                <svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
               </div>
               <div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">Instant Access</h3>
+                <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Instant Access</h3>
                 <p class="text-gray-600">Guests scan QR code and immediately see your menu - no waiting, no downloads.</p>
               </div>
             </div>
 
             <div class="flex items-start">
-              <div class="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center mr-4 mt-1">
-                <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center mr-4 mt-1">
+                <svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
               </div>
               <div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">Mobile-Friendly</h3>
+                <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Mobile-Friendly</h3>
                 <p class="text-gray-600">Optimized for smartphones with easy navigation and clear item descriptions.</p>
               </div>
             </div>
 
             <div class="flex items-start">
-              <div class="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center mr-4 mt-1">
-                <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center mr-4 mt-1">
+                <svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
               </div>
               <div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">Easy Ordering</h3>
+                <h3 class="text-lg font-semibold font-heading text-gray-900 mb-2">Easy Ordering</h3>
                 <p class="text-gray-600">Add items, review order, and place it with just a few taps. Simple and intuitive.</p>
               </div>
             </div>
@@ -292,7 +292,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
                 <span class="text-gray-900 font-medium">$18</span>
               </div>
             </div>
-            <button class="w-full bg-primary-400 text-white py-2 rounded-md mt-4 text-sm hover:bg-primary-500 transition-colors">
+            <button class="w-full bg-gray-200 text-gray-800 py-2 rounded-md mt-4 text-sm hover:bg-gray-300 transition-colors">
               Add to Order
             </button>
           </div>
@@ -302,9 +302,9 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   </section>
 
   <!-- Free Trial Section -->
-  <section class="py-20 bg-primary-50">
+  <section class="py-20 bg-gray-50">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+      <h2 class="text-3xl md:text-4xl font-bold font-heading text-gray-900 mb-6">
         Try letsorder Risk-Free
       </h2>
       <p class="text-xl text-gray-600 mb-8">
@@ -312,28 +312,28 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
       </p>
 
       <div class="bg-white rounded-lg p-8 shadow-sm border max-w-md mx-auto mb-8">
-        <h3 class="text-2xl font-bold text-gray-900 mb-4">30-Day Free Trial</h3>
+        <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">30-Day Free Trial</h3>
         <ul class="text-left space-y-2 text-gray-600 mb-6">
           <li class="flex items-center">
-            <svg class="w-4 h-4 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-gray-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
             </svg>
             Full access to all features
           </li>
           <li class="flex items-center">
-            <svg class="w-4 h-4 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-gray-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
             </svg>
             Up to 100 tables/rooms
           </li>
           <li class="flex items-center">
-            <svg class="w-4 h-4 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-gray-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
             </svg>
             Multiple manager accounts
           </li>
           <li class="flex items-center">
-            <svg class="w-4 h-4 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-gray-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
             </svg>
             No credit card required
@@ -341,7 +341,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         </ul>
       </div>
 
-      <a href={adminRegisterUrl} class="bg-primary-400 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-primary-500 transition-colors inline-block">
+      <a href={adminRegisterUrl} class="bg-gray-700 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-800 transition-colors inline-block">
         Start Your Free Trial
       </a>
     </div>

--- a/website/src/pages/live-demo.astro
+++ b/website/src/pages/live-demo.astro
@@ -15,13 +15,13 @@ const menuDemoNote =
 >
     <!-- Hero Section -->
     <section
-        class="bg-gradient-to-r from-primary-400 via-accent-400 to-secondary-400 text-white"
+        class="bg-gradient-to-r from-gray-600 via-gray-700 to-gray-800 text-white"
     >
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
             <div class="text-center">
-                <h1 class="text-4xl md:text-6xl font-bold mb-6">Live Demo</h1>
+                <h1 class="text-4xl md:text-6xl font-bold font-heading mb-6">Live Demo</h1>
                 <p
-                    class="text-xl md:text-2xl mb-8 text-pink-100 max-w-3xl mx-auto"
+                    class="text-xl md:text-2xl mb-8 text-gray-200 max-w-3xl mx-auto"
                 >
                     Experience letsorder in action. Access our live demo to
                     explore the features of our restaurant management and
@@ -37,7 +37,7 @@ const menuDemoNote =
             <div class="grid md:grid-cols-2 gap-12">
                 <!-- Admin Demo -->
                 <div class="bg-white p-8 rounded-lg shadow-md">
-                    <h2 class="text-2xl font-bold text-gray-900 mb-4">
+                    <h2 class="text-2xl font-bold font-heading text-gray-900 mb-4">
                         Admin Demo
                     </h2>
                     <p class="text-gray-600 mb-6">
@@ -58,11 +58,11 @@ const menuDemoNote =
                                 <!-- Admin Dashboard Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-primary-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-primary-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-600 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -93,11 +93,11 @@ const menuDemoNote =
                                 <!-- Menu Management Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-secondary-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-100 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-secondary-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-500 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -128,11 +128,11 @@ const menuDemoNote =
                                 <!-- QR Codes Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-accent-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-200 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-accent-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-700 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -165,13 +165,13 @@ const menuDemoNote =
                         <!-- Navigation Dots -->
                         <div class="flex justify-center mt-4 space-x-2">
                             <button
-                                class="admin-demo-dot w-2 h-2 bg-primary-400 rounded-full"
+                                class="admin-demo-dot w-2 h-2 bg-gray-600 rounded-full"
                                 data-slide="0"></button>
                             <button
-                                class="admin-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-primary-300"
+                                class="admin-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-gray-500"
                                 data-slide="1"></button>
                             <button
-                                class="admin-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-primary-300"
+                                class="admin-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-gray-500"
                                 data-slide="2"></button>
                         </div>
                     </div>
@@ -192,7 +192,7 @@ const menuDemoNote =
                     <a
                         href={adminDemoUrl}
                         target="_blank"
-                        class="w-full bg-primary-400 text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-primary-500 transition-colors block"
+                        class="w-full bg-gray-600 text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-gray-700 transition-colors block"
                     >
                         Launch Admin Demo
                     </a>
@@ -200,7 +200,7 @@ const menuDemoNote =
 
                 <!-- Menu Demo -->
                 <div class="bg-white p-8 rounded-lg shadow-md">
-                    <h2 class="text-2xl font-bold text-gray-900 mb-4">
+                    <h2 class="text-2xl font-bold font-heading text-gray-900 mb-4">
                         Menu Demo
                     </h2>
                     <p class="text-gray-600 mb-6">
@@ -221,11 +221,11 @@ const menuDemoNote =
                                 <!-- Menu Browse Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-secondary-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-100 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-secondary-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-500 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -256,11 +256,11 @@ const menuDemoNote =
                                 <!-- Cart Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-accent-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-200 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-accent-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-700 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -291,11 +291,11 @@ const menuDemoNote =
                                 <!-- Checkout Screenshot -->
                                 <div class="w-full flex-shrink-0 px-2">
                                     <div
-                                        class="bg-primary-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
+                                        class="bg-gray-50 rounded-lg aspect-[9/16] max-w-40 mx-auto flex items-center justify-center"
                                     >
                                         <div class="text-center p-4">
                                             <div
-                                                class="w-12 h-12 bg-primary-400 rounded-lg mx-auto mb-2 flex items-center justify-center"
+                                                class="w-12 h-12 bg-gray-600 rounded-lg mx-auto mb-2 flex items-center justify-center"
                                             >
                                                 <svg
                                                     class="w-6 h-6 text-white"
@@ -328,13 +328,13 @@ const menuDemoNote =
                         <!-- Navigation Dots -->
                         <div class="flex justify-center mt-4 space-x-2">
                             <button
-                                class="menu-demo-dot w-2 h-2 bg-secondary-400 rounded-full"
+                                class="menu-demo-dot w-2 h-2 bg-gray-600 rounded-full"
                                 data-slide="0"></button>
                             <button
-                                class="menu-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-secondary-300"
+                                class="menu-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-gray-500"
                                 data-slide="1"></button>
                             <button
-                                class="menu-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-secondary-300"
+                                class="menu-demo-dot w-2 h-2 bg-gray-300 rounded-full hover:bg-gray-500"
                                 data-slide="2"></button>
                         </div>
                     </div>
@@ -344,11 +344,11 @@ const menuDemoNote =
                             How to Access Menu Demo
                         </h3>
                         <div
-                            class="bg-blue-50 p-4 rounded-lg border border-blue-200"
+                            class="bg-gray-50 p-4 rounded-lg border border-gray-200"
                         >
                             <div class="flex items-start">
                                 <svg
-                                    class="w-5 h-5 text-blue-600 mt-0.5 mr-3 flex-shrink-0"
+                                    class="w-5 h-5 text-gray-600 mt-0.5 mr-3 flex-shrink-0"
                                     fill="none"
                                     stroke="currentColor"
                                     viewBox="0 0 24 24"
@@ -360,7 +360,7 @@ const menuDemoNote =
                                         d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                                     ></path>
                                 </svg>
-                                <p class="text-blue-800 text-sm">
+                                <p class="text-gray-800 text-sm">
                                     {menuDemoNote}
                                 </p>
                             </div>
@@ -393,7 +393,7 @@ const menuDemoNote =
                 <p class="text-gray-600">
                     Have questions? <a
                         href="/contact"
-                        class="text-primary-500 font-semibold hover:underline"
+                        class="text-gray-700 font-semibold hover:underline"
                         >Contact us</a
                     > for more information.
                 </p>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -12,7 +12,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   <!-- Hero Section -->
   <section class="bg-gray-50 py-16">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+      <h1 class="text-4xl md:text-5xl font-bold font-heading text-gray-900 mb-6">
         Simple, Transparent Pricing
       </h1>
       <p class="text-xl text-gray-600 mb-8">
@@ -28,7 +28,7 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
         <!-- Free Trial -->
         <div class="bg-white border-2 border-gray-200 rounded-lg p-8 text-center">
-          <h3 class="text-2xl font-bold text-gray-900 mb-4">Free Trial</h3>
+          <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">Free Trial</h3>
           <div class="mb-6">
             <span class="text-4xl font-bold text-gray-900">$0</span>
             <span class="text-gray-600">/30 days</span>
@@ -37,31 +37,31 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
           <ul class="text-left space-y-3 mb-8">
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Full access to all features
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Up to 100 tables/rooms
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Multiple manager accounts
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               QR code generation
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Real-time order management
@@ -74,12 +74,12 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
         </div>
 
         <!-- Standard Plan -->
-        <div class="bg-white border-2 border-blue-500 rounded-lg p-8 text-center relative">
+        <div class="bg-white border-2 border-gray-500 rounded-lg p-8 text-center relative">
           <div class="absolute -top-4 left-1/2 transform -translate-x-1/2">
-            <span class="bg-blue-500 text-white px-4 py-1 rounded-full text-sm font-medium">Most Popular</span>
+            <span class="bg-gray-600 text-white px-4 py-1 rounded-full text-sm font-medium">Most Popular</span>
           </div>
 
-          <h3 class="text-2xl font-bold text-gray-900 mb-4">Standard</h3>
+          <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">Standard</h3>
           <div class="mb-6">
             <span class="text-4xl font-bold text-gray-900">$60</span>
             <span class="text-gray-600">/year</span>
@@ -88,57 +88,57 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
           <ul class="text-left space-y-3 mb-8">
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               All features included
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Up to 100 tables/rooms
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Unlimited menu items
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Multiple manager accounts
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               QR code generation & printing
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Real-time order management
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Email support
             </li>
           </ul>
 
-          <a href={adminRegisterUrl} class="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors inline-block">
+          <a href={adminRegisterUrl} class="w-full bg-gray-700 text-white py-3 rounded-lg font-semibold hover:bg-gray-800 transition-colors inline-block">
             Get Started
           </a>
         </div>
 
         <!-- Enterprise -->
         <div class="bg-white border-2 border-gray-200 rounded-lg p-8 text-center">
-          <h3 class="text-2xl font-bold text-gray-900 mb-4">Enterprise</h3>
+          <h3 class="text-2xl font-bold font-heading text-gray-900 mb-4">Enterprise</h3>
           <div class="mb-6">
             <span class="text-4xl font-bold text-gray-900">Custom</span>
           </div>
@@ -146,31 +146,31 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
 
           <ul class="text-left space-y-3 mb-8">
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               All Standard features
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               100+ tables/rooms
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Priority support
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Custom integrations
             </li>
             <li class="flex items-center">
-              <svg class="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-gray-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               Dedicated account manager
@@ -188,31 +188,31 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   <!-- FAQ Section -->
   <section class="py-16 bg-gray-50">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl font-bold text-gray-900 text-center mb-12">Pricing FAQ</h2>
+      <h2 class="text-3xl font-bold font-heading text-gray-900 text-center mb-12">Pricing FAQ</h2>
 
       <div class="space-y-8">
         <div class="bg-white rounded-lg p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">Is there really a 30-day free trial?</h3>
+          <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Is there really a 30-day free trial?</h3>
           <p class="text-gray-600">Yes! You get full access to all features for 30 days with no credit card required. You can set up your restaurant, create menus, and test everything before deciding to subscribe.</p>
         </div>
 
         <div class="bg-white rounded-lg p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">What happens after the free trial?</h3>
+          <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What happens after the free trial?</h3>
           <p class="text-gray-600">After 30 days, you can choose to subscribe to our Standard plan for $60/year. If you don't subscribe, your account will be paused but your data will be preserved for 90 days.</p>
         </div>
 
         <div class="bg-white rounded-lg p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">Can I change plans later?</h3>
+          <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Can I change plans later?</h3>
           <p class="text-gray-600">Yes, you can upgrade to Enterprise at any time by contacting our sales team. We'll work with you to create a custom plan that fits your needs.</p>
         </div>
 
         <div class="bg-white rounded-lg p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">What payment methods do you accept?</h3>
+          <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">What payment methods do you accept?</h3>
           <p class="text-gray-600">We accept all major credit cards and bank transfers for annual payments. Payment is processed securely through our payment partners.</p>
         </div>
 
         <div class="bg-white rounded-lg p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">Is there a setup fee?</h3>
+          <h3 class="text-lg font-semibold font-heading text-gray-900 mb-3">Is there a setup fee?</h3>
           <p class="text-gray-600">No setup fees, no hidden costs. The price you see is exactly what you pay. We believe in transparent, simple pricing.</p>
         </div>
       </div>
@@ -220,13 +220,13 @@ const adminRegisterUrl = import.meta.env.PUBLIC_ADMIN_REGISTER_URL || "https://a
   </section>
 
   <!-- CTA Section -->
-  <section class="py-16 bg-blue-600 text-white">
+  <section class="py-16 bg-gray-700 text-white">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl font-bold mb-6">Ready to Get Started?</h2>
-      <p class="text-xl text-blue-100 mb-8">
+      <h2 class="text-3xl font-bold font-heading mb-6">Ready to Get Started?</h2>
+      <p class="text-xl text-gray-200 mb-8">
         Join restaurants already using letsorder to streamline their operations.
       </p>
-      <a href={adminRegisterUrl} class="bg-white text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors inline-block">
+      <a href={adminRegisterUrl} class="bg-white text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors inline-block">
         Start Your Free Trial
       </a>
     </div>

--- a/website/tailwind.config.mjs
+++ b/website/tailwind.config.mjs
@@ -3,6 +3,9 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     extend: {
+      fontFamily: {
+        'heading': ['Crimson Pro', 'serif'],
+      },
       colors: {
         primary: {
           50: '#fdf2f8',


### PR DESCRIPTION
- Replace colorful brand theme with professional grayscale design
- Apply Crimson Pro serif font to all headings and titles
- Update navigation brand name from "letsorder" to "Lets Order\!"
- Convert hero sections from colored gradients to gray gradients
- Replace primary/secondary/accent colors with gray variants across all pages
- Update buttons, carousel elements, and icons to grayscale
- Make homepage hero heading lighter weight and larger size
- Remove CTA buttons from footer for cleaner design
- Ensure consistent font-heading class usage throughout

🤖 Generated with [Claude Code](https://claude.ai/code)